### PR TITLE
Updated .csproj

### DIFF
--- a/DuoDesktop/DuoDesktop.csproj
+++ b/DuoDesktop/DuoDesktop.csproj
@@ -38,21 +38,20 @@
 		<ProjectCapability Include="Msix" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.0-preview1.25120.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.0-preview.4.25258.110">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.3" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
-		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3124.44" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.4.25258.110" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0-preview.4.25258.110" />
+		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.8.250515001-experimental2" />
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3296-prerelease" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
 		<PackageReference Include="Moq" Version="4.20.72" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+		<PackageReference Include="MSTest.TestFramework" Version="3.9.0" />
+		<PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
@@ -74,7 +73,12 @@
 		<Folder Include="Repositories\Interfaces\" />
 	</ItemGroup>
 	<ItemGroup>
-	  <ProjectReference Include="..\DuolingoClassLibrary\DuolingoClassLibrary.csproj" />
+	  <ProjectReference Include="..\DuoClassLibrary\DuoClassLibrary.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Reference Include="DuoClassLibrary">
+	    <HintPath>..\DuoClassLibrary\bin\Debug\net8.0\DuoClassLibrary.dll</HintPath>
+	  </Reference>
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Update="MainWindow.xaml.cs">


### PR DESCRIPTION
#### PR Classification
Dependency updates and project reference restructuring.

#### PR Summary
The `DuoDesktop.csproj` file has been updated to include newer versions of several package references and to change the project reference from `DuolingoClassLibrary` to `DuoClassLibrary`. Additionally, a new reference to the compiled output of `DuoClassLibrary` has been added. 
- `DuoDesktop.csproj`: Updated package references to newer versions, including `Microsoft.Data.SqlClient` and `Microsoft.EntityFrameworkCore.Tools`.
- `DuoDesktop.csproj`: Changed project reference from `DuolingoClassLibrary` to `DuoClassLibrary`.
- `DuoDesktop.csproj`: Added a new reference for `DuoClassLibrary` with a hint path to the DLL.
- `DuoDesktop.csproj`: Updated `MSTest.TestFramework` and `StyleCop.Analyzers` to newer versions.
