### PR TITLE
Fix tag filtering

### DIFF
--- a/DuoClassLibrary/Models/Tag.cs
+++ b/DuoClassLibrary/Models/Tag.cs
@@ -31,7 +31,7 @@ namespace DuoClassLibrary.Models
                 if (isSelected != value)
                 {
                     isSelected = value;
-                    OnPropertyChanged(nameof(isSelected));
+                    OnPropertyChanged();
                 }
             }
         }


### PR DESCRIPTION
This pull request refactors the `MainViewModel` class in the `Duo` application to improve tag management and filtering logic. The key changes include introducing batch updates for filters to prevent unnecessary re-filtering, refactoring tag property change handling, and simplifying property change notifications in the `Tag` model.

### Improvements to tag management:

* [`Duo/ViewModels/MainViewModel.cs`](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eR61-R80): Updated the `AvailableTags` property to unsubscribe from old tags and subscribe to new tags when the collection changes, ensuring proper cleanup and event handling.
* [`Duo/ViewModels/MainViewModel.cs`](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eR360-R376): Introduced the `Tag_PropertyChanged` method to handle property changes for tags, applying filters only when a tag's selection state changes and batch updates are not active.

### Enhancements to filtering logic:

* [`Duo/ViewModels/MainViewModel.cs`](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eR201-R205): Added a private `isUpdatingFiltersBatch` flag to prevent redundant filtering operations during batch updates, and integrated this flag into the `ResetAllFilters` method. [[1]](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eR201-R205) [[2]](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eL267-R279)

### Simplification of property change notifications:

* [`DuoClassLibrary/Models/Tag.cs`](diffhunk://#diff-06edb896938648878d888127a249f13075817bcf94f9b95270e86b483aee3764L34-R34): Simplified the `OnPropertyChanged` invocation in the `IsSelected` property of the `Tag` model by removing the explicit property name argument.

### Cleanup of redundant code:

* [`Duo/ViewModels/MainViewModel.cs`](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eL211-L214): Removed the `OnTagSelectionChanged` method and its associated event subscriptions, as its functionality has been replaced by the new `Tag_PropertyChanged` method. [[1]](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eL211-L214) [[2]](diffhunk://#diff-77d5c540a67ec96c1f865227e1b9dcf0dfc114c7f57c1fe45d4e471a77855b6eL242-R268)