### PR TITLE
Fix flashcard exercise on web

### DIFF
--- a/WebServerTest/Views/Exercise/_FlashcardExerciseForm.cshtml
+++ b/WebServerTest/Views/Exercise/_FlashcardExerciseForm.cshtml
@@ -188,8 +188,7 @@
             if (timeLeft <= 0) {
                 clearInterval(timer);
                 flipCard();
-                // Add the alert when time runs out
-                alert("Time is up");
+				document.dispatchEvent(new Event('timeUp'));
             }
         }, 1000);
 

--- a/WebServerTest/Views/Quiz/Solve.cshtml
+++ b/WebServerTest/Views/Quiz/Solve.cshtml
@@ -92,13 +92,13 @@
         {
             <text>
             const answerInput = document.getElementById('answerInput');
-            if (!answerInput.value.trim()) {
-                feedbackMessage.style.display = 'block';
-                feedbackMessage.className = 'alert alert-warning mt-3';
-                feedbackText.textContent = 'Please enter an answer.';
-                submitButton.disabled = false;
-                return;
-            }
+            // if (!answerInput.value.trim()) {
+            //     feedbackMessage.style.display = 'block';
+            //     feedbackMessage.className = 'alert alert-warning mt-3';
+            //     feedbackText.textContent = 'Please enter an answer.';
+            //     submitButton.disabled = false;
+            //     return;
+            // }
             answer = answerInput.value;
             </text>
         }

--- a/WebServerTest/Views/Quiz/Solve.cshtml
+++ b/WebServerTest/Views/Quiz/Solve.cshtml
@@ -76,6 +76,10 @@
 </form>
 
 <script>
+    document.addEventListener('timeUp', function() {
+		validateExercise();
+    })
+
     async function validateExercise() {
         const form = document.getElementById('exerciseForm');
         const submitButton = document.getElementById('submitButton');


### PR DESCRIPTION
### This PR will fix the FlashcarExercise solving in a Quiz from the Roadmap on the web client
This is will also remove the posibility that the user remains blocked when time is up and they haven't submitted any answer.
- remove the check that enforces the input to not be empty
- automatically submit answer when time is up, by dispatching a 'timeUp' event from the [_FlashcardExerciseForm.cshtml](https://github.com/UBB-SE-922-1/Duo/compare/fix-flashcard-exercise?expand=1#diff-7b287b67e13930d5d859c61dc0a7cffc4d0c2785d6fbe4ec582ebf14a023cc59) and listening for it in [Solve.cshtml](https://github.com/UBB-SE-922-1/Duo/compare/fix-flashcard-exercise?expand=1#diff-231c377e340f1637804d406e4c9eb113fadab1136504a364c5691dbd246bba8d)